### PR TITLE
Update contribution_workflow.md to correct name (#410)

### DIFF
--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -1,6 +1,6 @@
 # Contribution Workflow
 
-You can contribute to WinUI with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated.
+You can contribute to ModernFlyouts with issues and PRs. Simply filing issues for problems you encounter is a great way to contribute. Contributing implementations is greatly appreciated.
 
 Please make sure you have some basic knowledge in git and GitHub workflow.
 


### PR DESCRIPTION
Currently, contribution_workflow.md says "You can contribute to WinUI with issues and PRs." as opposed to "You can contribute to ModernFlyouts with issues and PRs.", this commit fixes that.