### PR TITLE
Fix Wrong Translation in Chinese

### DIFF
--- a/ModernFlyouts/MultilingualResources/ModernFlyouts.zh-CN.xlf
+++ b/ModernFlyouts/MultilingualResources/ModernFlyouts.zh-CN.xlf
@@ -70,11 +70,11 @@
         </trans-unit>
         <trans-unit id="RestoreDefaultItem" translate="yes" xml:space="preserve">
           <source>Restore legacy flyout</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">还原默认弹窗</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">还原默认浮出控件</target>
         </trans-unit>
         <trans-unit id="RestoreDefaultItemDescription" translate="yes" xml:space="preserve">
           <source>Restores the windows default flyout and safely quits this app</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">还原 Windows 的默认弹窗并安全退出此应用程序</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">还原 Windows 的默认浮出控件并安全退出此应用程序</target>
         </trans-unit>
         <trans-unit id="SessionControl.MoreControls" translate="yes" xml:space="preserve">
           <source>More Controls</source>
@@ -134,15 +134,15 @@
         </trans-unit>
         <trans-unit id="Settings.DefaultFlyout" translate="yes" xml:space="preserve">
           <source>Default Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">默认弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">默认浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.DefaultFlyoutDescription" translate="yes" xml:space="preserve">
           <source>Select the default flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择默认的弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择默认的浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.DefaultFlyoutWarningMessage" translate="yes" xml:space="preserve">
           <source>Choosing the Windows Default Flyout as default won't close this app. This app will still keep running in the background. Please exit this app safely to improve performance.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择 Windows 默认弹窗不会关闭此应用。此应用程序仍将在后台继续运行。请安全地退出此应用程序以提高性能。</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择 Windows 默认浮出控件不会关闭此应用。此应用程序仍将在后台继续运行。请安全地退出此应用程序以提高性能。</target>
         </trans-unit>
         <trans-unit id="Settings.Disabled" translate="yes" xml:space="preserve">
           <source>Disabled</source>
@@ -154,36 +154,36 @@
         </trans-unit>
         <trans-unit id="Settings.FlyoutBackgroundOpacity" translate="yes" xml:space="preserve">
           <source>Flyout background opacity</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">弹窗背景不透明度</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">浮出控件背景不透明度</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutDefaultPosition" translate="yes" xml:space="preserve">
           <source>Flyout default position</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">弹窗默认位置（用于恢复默认位置按钮）</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">浮出控件默认位置（用于恢复默认位置按钮）</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutTopBar" translate="yes" xml:space="preserve">
           <source>Flyout TopBar</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">弹窗顶栏</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">浮出控件顶栏</target>
         </trans-unit>
         <trans-unit id="Settings.Modules" translate="yes" xml:space="preserve">
           <source>Flyout modules</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">弹窗模块</target>
+          <target state="needs-review-translation" state-qualifier="tm-suggestion">浮出控件模块</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Settings.Modules.Airplane" translate="yes" xml:space="preserve">
           <source>Airplane mode</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">飞行模式弹窗模块</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">飞行模式浮出控件模块</target>
         </trans-unit>
         <trans-unit id="Settings.Modules.Audio" translate="yes" xml:space="preserve">
           <source>Audio</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">音频弹窗模块</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">音频浮出控件模块</target>
         </trans-unit>
         <trans-unit id="Settings.Modules.Brightness" translate="yes" xml:space="preserve">
           <source>Brightness</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">亮度弹窗模块</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">亮度浮出控件模块</target>
         </trans-unit>
         <trans-unit id="Settings.Modules.LockKeys" translate="yes" xml:space="preserve">
           <source>Lock keys</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">锁定键弹窗模块</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">锁定键浮出控件模块</target>
         </trans-unit>
         <trans-unit id="Settings.RunAtStartup" translate="yes" xml:space="preserve">
           <source>Run at startup</source>
@@ -223,7 +223,7 @@
         </trans-unit>
         <trans-unit id="About.AppDescription" translate="yes" xml:space="preserve">
           <source>This app is designed to be a modern Fluent Design replacement for the old metro themed flyouts present in Windows since Windows 8.</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">该程序用于将旧的 Windows 8 Metro 风格弹窗覆盖为 Fluent Design 风格弹窗。</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">该程序用于将旧的 Windows 8 Metro 风格浮出控件覆盖为 Fluent Design 风格浮出控件。</target>
         </trans-unit>
         <trans-unit id="About.Contributors" translate="yes" xml:space="preserve">
           <source>Contributors</source>
@@ -275,11 +275,11 @@
         </trans-unit>
         <trans-unit id="AudioFlyoutHelper.ShowGSMTCInVolumeFlyout" translate="yes" xml:space="preserve">
           <source>Show Global System Media Transport Controls (GSMTC) aka Media controls in Volume flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">在音量弹窗中显示系统全局媒体传输 / 媒体控制</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">在音量浮出控件中显示系统全局媒体传输 / 媒体控制</target>
         </trans-unit>
         <trans-unit id="AudioFlyoutHelper.ShowVolumeControlInGSMTCFlyout" translate="yes" xml:space="preserve">
           <source>Show Volume control in Global System Media Transport Controls (GSMTC) aka Media flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">在媒体弹窗中显示音量控制</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">在媒体浮出控件中显示音量控制</target>
         </trans-unit>
         <trans-unit id="AudioFlyoutHelper.ThumbnailAlignment" translate="yes" xml:space="preserve">
           <source>Thumbnail alignment</source>
@@ -323,7 +323,7 @@
         </trans-unit>
         <trans-unit id="LockKeysFlyoutHelper.SelectKeyDescription" translate="yes" xml:space="preserve">
           <source>Select the keys you want to show the flyout for</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择要显示的弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">选择要显示的浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.Appearance" translate="yes" xml:space="preserve">
           <source>Appearance</source>
@@ -331,27 +331,27 @@
         </trans-unit>
         <trans-unit id="Settings.EnableModule.Airplane" translate="yes" xml:space="preserve">
           <source>Enable Airplane mode Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用飞行模式弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用飞行模式浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.EnableModule.Audio" translate="yes" xml:space="preserve">
           <source>Enable Audio Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用音频弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用音频浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.EnableModule.Brightness" translate="yes" xml:space="preserve">
           <source>Enable Brightness Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用亮度弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用亮度浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.EnableModule.LockKeys" translate="yes" xml:space="preserve">
           <source>Enable Lock keys Flyout</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用锁定键弹窗</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">启用锁定键浮出控件</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutTheme" translate="yes" xml:space="preserve">
           <source>Flyout theme</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">弹窗主题</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">浮出控件主题</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutTimeout" translate="yes" xml:space="preserve">
           <source>Flyout timeout (ms)</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">弹窗超时（毫秒 / ms）</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">浮出控件超时（毫秒 / ms）</target>
         </trans-unit>
         <trans-unit id="Settings.Left" translate="yes" xml:space="preserve">
           <source>Left</source>
@@ -403,7 +403,7 @@
         </trans-unit>
         <trans-unit id="Settings.AlignFlyout" translate="yes" xml:space="preserve">
           <source>Align flyout to this position</source>
-          <target state="needs-review-translation" state-qualifier="mt-suggestion">将弹窗对齐到此位置</target>
+          <target state="needs-review-translation" state-qualifier="mt-suggestion">将浮出控件对齐到此位置</target>
         </trans-unit>
         <trans-unit id="Settings.RestartRequired" translate="yes" xml:space="preserve">
           <source>Restart required to apply some changes</source>
@@ -475,23 +475,23 @@
         </trans-unit>
         <trans-unit id="Settings.DisplayDescription" translate="yes" xml:space="preserve">
           <source>Select the preferred display monitor to show the flyout on</source>
-          <target state="new">选择需要弹窗的显示器</target>
+          <target state="new">选择显示浮出控件的显示器</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutAlignment" translate="yes" xml:space="preserve">
           <source>Flyout alignment</source>
-          <target state="new">弹窗对齐方式</target>
+          <target state="new">浮出控件对齐方式</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutContentStackingDirection" translate="yes" xml:space="preserve">
           <source>Flyout content stacking direction</source>
-          <target state="new">弹窗内容堆叠方向</target>
+          <target state="new">浮出控件内容堆叠方向</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutExpandDirection" translate="yes" xml:space="preserve">
           <source>Flyout expand direction</source>
-          <target state="new">弹窗展开方向</target>
+          <target state="new">浮出控件展开方向</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutPlacement" translate="yes" xml:space="preserve">
           <source>Flyout placement</source>
-          <target state="new">弹窗展现</target>
+          <target state="new">浮出控件展现</target>
         </trans-unit>
         <trans-unit id="Settings.FlyoutPlacementMode" translate="yes" xml:space="preserve">
           <source>Placement mode</source>
@@ -503,7 +503,7 @@
         </trans-unit>
         <trans-unit id="Settings.Layout" translate="yes" xml:space="preserve">
           <source>Layout</source>
-          <target state="new">展现</target>
+          <target state="new">布局</target>
         </trans-unit>
         <trans-unit id="Settings.VerticalAlignment" translate="yes" xml:space="preserve">
           <source>Vertical alignment</source>


### PR DESCRIPTION
Flyout should be translated to "浮出控件" as it's the official translation from [Microsoft’s docs](https://docs.microsoft.com/zh-cn/windows/uwp/design/controls-and-patterns/dialogs-and-flyouts/)