### PR TITLE
feat: click session-control bg to close it

### DIFF
--- a/ModernFlyouts/Controls/SessionControl.xaml
+++ b/ModernFlyouts/Controls/SessionControl.xaml
@@ -41,7 +41,9 @@
                 </Border.Background>
             </Border>
 
-            <Border Opacity="0" Grid.ColumnSpan="3" Grid.RowSpan="3" Background="#fff" CornerRadius="{DynamicResource FlyoutCornerRadius}" ClipToBounds="True">
+            <Border Opacity="0" Grid.ColumnSpan="3" Grid.RowSpan="3" Background="#fff" CornerRadius="{DynamicResource FlyoutCornerRadius}" ClipToBounds="True"
+                    Visibility="{Binding Source={x:Static local:FlyoutHandler.Instance}, Path=UIManager.CloseMediaFlyoutOnBgClick,
+                        Converter={StaticResource BooleanToVisibilityConverter}}">
                 <Border.InputBindings>
                     <MouseBinding MouseAction="LeftClick"
                                   Command="{x:Static utils:CommonCommands.CloseFlyoutCommand}"

--- a/ModernFlyouts/Controls/SessionControl.xaml
+++ b/ModernFlyouts/Controls/SessionControl.xaml
@@ -27,6 +27,11 @@
             <Border Grid.ColumnSpan="3" Grid.RowSpan="3" Opacity="0.5" CornerRadius="{DynamicResource FlyoutCornerRadius}" ClipToBounds="True"
                     Visibility="{Binding Source={x:Static local:FlyoutHandler.Instance}, Path=UIManager.UseGSMTCThumbnailAsBackground,
                         Converter={StaticResource BooleanToVisibilityConverter}}">
+                <Border.InputBindings>
+                    <MouseBinding MouseAction="LeftClick"
+                                  Command="{x:Static utils:CommonCommands.CloseFlyoutCommand}"
+                                  CommandParameter="{x:Reference Name=ContentGrid}" />
+                </Border.InputBindings>
                 <Border.OpacityMask>
                     <RadialGradientBrush x:Name="thumbnailBGOpacityBrush" x:FieldModifier="private"
                                          GradientOrigin="1,0.5" RadiusX="1" RadiusY="1" Center="1,0.5">

--- a/ModernFlyouts/Controls/SessionControl.xaml
+++ b/ModernFlyouts/Controls/SessionControl.xaml
@@ -27,11 +27,6 @@
             <Border Grid.ColumnSpan="3" Grid.RowSpan="3" Opacity="0.5" CornerRadius="{DynamicResource FlyoutCornerRadius}" ClipToBounds="True"
                     Visibility="{Binding Source={x:Static local:FlyoutHandler.Instance}, Path=UIManager.UseGSMTCThumbnailAsBackground,
                         Converter={StaticResource BooleanToVisibilityConverter}}">
-                <Border.InputBindings>
-                    <MouseBinding MouseAction="LeftClick"
-                                  Command="{x:Static utils:CommonCommands.CloseFlyoutCommand}"
-                                  CommandParameter="{x:Reference Name=ContentGrid}" />
-                </Border.InputBindings>
                 <Border.OpacityMask>
                     <RadialGradientBrush x:Name="thumbnailBGOpacityBrush" x:FieldModifier="private"
                                          GradientOrigin="1,0.5" RadiusX="1" RadiusY="1" Center="1,0.5">
@@ -44,6 +39,14 @@
                                 RenderOptions.BitmapScalingMode="HighQuality">
                     </ImageBrush>
                 </Border.Background>
+            </Border>
+
+            <Border Opacity="0" Grid.ColumnSpan="3" Grid.RowSpan="3" Background="#fff" CornerRadius="{DynamicResource FlyoutCornerRadius}" ClipToBounds="True">
+                <Border.InputBindings>
+                    <MouseBinding MouseAction="LeftClick"
+                                  Command="{x:Static utils:CommonCommands.CloseFlyoutCommand}"
+                                  CommandParameter="{x:Reference Name=ContentGrid}" />
+                </Border.InputBindings>
             </Border>
 
             <Grid x:Name="TextBlockGrid" Grid.Column="1" VerticalAlignment="Center" Margin="0,25,0,0" Cursor="Hand"

--- a/ModernFlyouts/Helpers/AppDataHelper.cs
+++ b/ModernFlyouts/Helpers/AppDataHelper.cs
@@ -301,6 +301,12 @@ namespace ModernFlyouts.Helpers
             set => SetValue(value);
         }
 
+        public static bool CloseMediaFlyoutOnBgClick
+        {
+            get => GetValue(DefaultValuesStore.CloseMediaFlyoutOnBgClick);
+            set => SetValue(value);
+        }
+
         public static int MaxVerticalSessionControlsCount
         {
             get => GetValue(DefaultValuesStore.MaxVerticalSessionControlsCount);

--- a/ModernFlyouts/Helpers/DefaultValuesStore.cs
+++ b/ModernFlyouts/Helpers/DefaultValuesStore.cs
@@ -86,6 +86,8 @@ namespace ModernFlyouts.Helpers
 
         public const bool UseGSMTCThumbnailAsBackground = true;
 
+        public const bool CloseMediaFlyoutOnBgClick = false;
+
         public const int MaxVerticalSessionControlsCount = 1;
 
         public const Orientation SessionsPanelOrientation = Orientation.Horizontal;

--- a/ModernFlyouts/Navigation/AudioModulePage.xaml
+++ b/ModernFlyouts/Navigation/AudioModulePage.xaml
@@ -41,6 +41,9 @@
                         <ui:ToggleSwitch Header="{x:Static resx:Strings.AudioFlyoutHelper_UseThumbnailAsBackground}"
                                          OnContent="{x:Static resx:Strings.Settings_On}" OffContent="{x:Static resx:Strings.Settings_Off}"
                                          IsOn="{Binding UIManager.UseGSMTCThumbnailAsBackground}" />
+                        <ui:ToggleSwitch Header="{x:Static resx:Strings.AudioFlyoutHelper_CloseMediaFlyoutOnBgClick}"
+                                         OnContent="{x:Static resx:Strings.Settings_On}" OffContent="{x:Static resx:Strings.Settings_Off}"
+                                         IsOn="{Binding UIManager.CloseMediaFlyoutOnBgClick}" />
                         <ui:RadioButtons x:Name="orientationCmbBox" x:FieldModifier="private"
                                          Header="{x:Static resx:Strings.AudioFlyoutHelper_SessionsPanelOrientation}"
                                          ItemTemplate="{StaticResource LocalizedEnumItemTemplate}"

--- a/ModernFlyouts/Properties/Strings.Designer.cs
+++ b/ModernFlyouts/Properties/Strings.Designer.cs
@@ -239,6 +239,15 @@ namespace ModernFlyouts.Properties {
                 return ResourceManager.GetString("AudioFlyoutHelper.UseThumbnailAsBackground", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Close media flyout when the background is clicked.
+        /// </summary>
+        public static string AudioFlyoutHelper_CloseMediaFlyoutOnBgClick {
+            get {
+                return ResourceManager.GetString("AudioFlyoutHelper.CloseMediaFlyoutOnBgClick", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Close.

--- a/ModernFlyouts/Properties/Strings.resx
+++ b/ModernFlyouts/Properties/Strings.resx
@@ -177,6 +177,9 @@
   <data name="AudioFlyoutHelper.UseThumbnailAsBackground" xml:space="preserve">
     <value>Use media's thumbnail as media control's background</value>
   </data>
+  <data name="AudioFlyoutHelper.CloseMediaFlyoutOnBgClick" xml:space="preserve">
+    <value>Close media flyout when the background is clicked</value>
+  </data>
   <data name="Close" xml:space="preserve">
     <value>Close</value>
   </data>

--- a/ModernFlyouts/UI/UIManager.cs
+++ b/ModernFlyouts/UI/UIManager.cs
@@ -255,6 +255,20 @@ namespace ModernFlyouts.UI
             }
         }
 
+        private bool closeMediaFlyoutOnBgClick = DefaultValuesStore.CloseMediaFlyoutOnBgClick;
+
+        public bool CloseMediaFlyoutOnBgClick
+        {
+            get => closeMediaFlyoutOnBgClick;
+            set
+            {
+                if (SetProperty(ref closeMediaFlyoutOnBgClick, value))
+                {
+                    AppDataHelper.CloseMediaFlyoutOnBgClick = value;
+                }
+            }
+        }
+
         private Orientation sessionsPanelOrientation = DefaultValuesStore.SessionsPanelOrientation;
 
         public Orientation SessionsPanelOrientation
@@ -315,6 +329,7 @@ namespace ModernFlyouts.UI
             FlyoutTimeout = AppDataHelper.FlyoutTimeout;
             AlignGSMTCThumbnailToRight = AppDataHelper.AlignGSMTCThumbnailToRight;
             UseGSMTCThumbnailAsBackground = AppDataHelper.UseGSMTCThumbnailAsBackground;
+            CloseMediaFlyoutOnBgClick = AppDataHelper.CloseMediaFlyoutOnBgClick;
             MaxVerticalSessionControlsCount = AppDataHelper.MaxVerticalSessionControlsCount;
             SessionsPanelOrientation = AppDataHelper.SessionsPanelOrientation;
 


### PR DESCRIPTION
Closes #415 

I am not a WPF developer and I am shooting in the dark here, so bear with me.

<s>This PR does close the flyout when clicking an empty space on the thumbnail but if the thumbnail option is turned of, it won't work and If I understand correctly, that's because of `BooleanToVisibilityConverter` which converts `false` to `Collapsed` and not `Hidden`.</s>

<s>I tried to add a new empty `Border` after the thumbnail but it didn't work, I don't know why (poor wpf skills 😅).</s> Just needed to give it a Background color lol.

<s>The other thing that might work (haven't tested it), is to make a custom `BooleanToVisibilityConverter` which converts `false` to `Hidden` but that seemed overkill imo.</s> Won't work as `Hidden` will make all clicks go through.

