### PR TITLE
[NativeFlyoutHandler] Do some minor changes to hide Windows 11 22H2's native flyout bar.

### DIFF
--- a/ModernFlyouts.Core/Interop/NativeFlyoutHandler.cs
+++ b/ModernFlyouts.Core/Interop/NativeFlyoutHandler.cs
@@ -341,7 +341,6 @@ namespace ModernFlyouts.Core.Interop
         private bool GetAllInfos()
         {
             IntPtr hWndHost;
-            _ = Environment.OSVersion.Version.Build;
             while ((hWndHost = FindWindowEx(IntPtr.Zero, IntPtr.Zero, Environment.OSVersion.Version.Build > 22000 ? "XamlExplorerHostIslandWindow" : "NativeHWNDHost", "")) != IntPtr.Zero)
             {
                 IntPtr hWndDUI;

--- a/ModernFlyouts.Core/Interop/NativeFlyoutHandler.cs
+++ b/ModernFlyouts.Core/Interop/NativeFlyoutHandler.cs
@@ -341,10 +341,11 @@ namespace ModernFlyouts.Core.Interop
         private bool GetAllInfos()
         {
             IntPtr hWndHost;
-            while ((hWndHost = FindWindowEx(IntPtr.Zero, IntPtr.Zero, "NativeHWNDHost", "")) != IntPtr.Zero)
+            _ = Environment.OSVersion.Version.Build;
+            while ((hWndHost = FindWindowEx(IntPtr.Zero, IntPtr.Zero, Environment.OSVersion.Version.Build > 22000 ? "XamlExplorerHostIslandWindow" : "NativeHWNDHost", "")) != IntPtr.Zero)
             {
                 IntPtr hWndDUI;
-                if ((hWndDUI = FindWindowEx(hWndHost, IntPtr.Zero, "DirectUIHWND", "")) != IntPtr.Zero)
+                if ((hWndDUI = FindWindowEx(hWndHost, IntPtr.Zero, Environment.OSVersion.Version.Build > 22000 ? "Windows.UI.Composition.DesktopWindowContentBridge" : "DirectUIHWND", Environment.OSVersion.Version.Build > 22000 ? "DesktopWindowXamlSource" : "")) != IntPtr.Zero)
                 {
                     GetWindowThreadProcessId(hWndHost, out int pid);
                     if (Process.GetProcessById(pid).ProcessName.ToLower() == "explorer")


### PR DESCRIPTION
As far as I know, the Windows 11 22H2 changed the window that displays the native flyout bar. So the old method doesn't work now. 
To fix this, I changed the method. Now the program will automatically change the target hwnd to hide.