### PR TITLE
update SMTC support status of NetEase Cloud Music

### DIFF
--- a/docs/GSMTC-Support-And-Popular-Apps.md
+++ b/docs/GSMTC-Support-And-Popular-Apps.md
@@ -99,7 +99,7 @@ NOTE- Chromium based includes Chromium browsers and its derivatives (Chrome, New
 - **Winamp** - https://github.com/NanMetal/gen_smtc
 - **MPV** - <sup><a name="f1">1</a></sup>https://github.com/x0wllaar/MPV-SMTC OR
           - <sup><a name="f2">2</a></sup>https://github.com/datasone/MPVMediaControl
-
+- **Netease Cloud Music** - https://github.com/BetterNCM/InfinityLink
 ## Help us include support for more applications that are currently unsupported
 
 - **VLC** : We have filed a [feature request on VLC's bug tracker site](https://trac.videolan.org/vlc/ticket/25258#ticket) asking built-in support for the SMTC APIs for the VLC Desktop (Win32) app.

--- a/docs/GSMTC-Support-And-Popular-Apps.md
+++ b/docs/GSMTC-Support-And-Popular-Apps.md
@@ -55,7 +55,7 @@ Users tend to know which functionalities are supported by ModernFlyouts' Media S
 | [Quod Libet](https://quodlibet.readthedocs.io/en/latest/downloads.html) | 🔴 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 |
 | [MusicPlayer2](https://github.com/zhongyang219/MusicPlayer2/) | 🔴 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 |
 | [Strawberry](https://www.strawberrymusicplayer.org/#download) | 🔴 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 |
-| [NetEase Cloud Music](https://music.163.com/#/download) | 🔴 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 |
+| [NetEase Cloud Music](https://music.163.com/#/download) | 🟡 | 🟩 | 🟩 | 🟩 | 🟩 | 🟪 | 🟩 | 🟩 | 🟩 | 🟥 | 🟥 | 🟥 |
 | [QQ Music](https://y.qq.com/download) | 🔴 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 | 🟥 |
 
 ##### Video:


### PR DESCRIPTION
NetEase Cloud Music already has an implementation of SMTC by a plugin of [BetterNCM](https://github.com/MicroCBer/BetterNCM) whose name is `InfLink`.

![image](https://user-images.githubusercontent.com/66859419/212084755-c7a99bf5-d290-4293-96a5-f27aa5780632.png)
![image](https://user-images.githubusercontent.com/66859419/212084887-f9a46a07-bd37-4e7e-8f74-f6a72561eb80.png)
